### PR TITLE
JA4_r

### DIFF
--- a/ja4.go
+++ b/ja4.go
@@ -68,14 +68,20 @@ func ja4a(tls TLSDetails) string {
 
 	return fmt.Sprintf("%v%v%v%v%v%v", proto, tlsVersion, sniMode, numSuites, numExtensions, firstALPN)
 }
-func ja4b(tls TLSDetails) string {
+
+func ja4b_r(tls TLSDetails) string {
 	suites := strings.Split(strings.Split(tls.JA3, ",")[1], "-")
 	parsed := toHexAll(suites, false, true)
 	// fmt.Println("ja4b:", strings.Join(parsed, ","))
-	return sha256trunc(strings.Join(parsed, ","))
+	return strings.Join(parsed, ",")
 }
 
-func ja4c(tls TLSDetails) string {
+func ja4b(tls TLSDetails) string {
+	result := ja4b_r(tls)
+	return sha256trunc(result)
+}
+
+func ja4c_r(tls TLSDetails) string {
 	extensions := strings.Split(strings.Split(tls.JA3, ",")[2], "-")
 	sigAlgs := strings.Split(strings.Split(tls.PeetPrint, "|")[3], "-")
 
@@ -88,9 +94,18 @@ func ja4c(tls TLSDetails) string {
 	parsedAlg := toHexAll(sigAlgs, false, false)
 	parsed := strings.Join(parsedExt, ",") + "_" + strings.Join(parsedAlg, ",")
 	// fmt.Println("ja4c:", parsed)
-	return sha256trunc(parsed)
+	return parsed
+}
+
+func ja4c(tls TLSDetails) string {
+	result := ja4c_r(tls)
+	return sha256trunc(result)
 }
 
 func CalculateJa4(tls TLSDetails) string {
 	return ja4a(tls) + "_" + ja4b(tls) + "_" + ja4c(tls)
+}
+
+func CalculateJa4_r(tls TLSDetails) string {
+	return ja4a(tls) + "_" + ja4b_r(tls) + "_" + ja4c_r(tls)
 }

--- a/router.go
+++ b/router.go
@@ -23,6 +23,7 @@ func Router(path string, res Response) ([]byte, string) {
 		res.TCPIP = v.(TCPIPDetails)
 	}
 	res.TLS.JA4 = CalculateJa4(res.TLS)
+	res.TLS.JA4_r = CalculateJa4_r(res.TLS)
 	res.Donate = "Please consider donating to keep this API running. Visit https://tls.peet.ws"
 	Log(fmt.Sprintf("%v %v %v %v %v", cleanIP(res.IP), res.Method, res.HTTPVersion, res.path, res.TLS.JA3Hash))
 	// if GetUserAgent(res) == "" {

--- a/routes.go
+++ b/routes.go
@@ -35,6 +35,7 @@ func apiClean(res Response, _ url.Values) ([]byte, string) {
 		JA3:           res.TLS.JA3,
 		JA3Hash:       res.TLS.JA3Hash,
 		JA4:           res.TLS.JA4,
+		JA4_r:           res.TLS.JA4_r,
 		Akamai:        akamai,
 		AkamaiHash:    hash,
 		PeetPrint:     res.TLS.PeetPrint,

--- a/structs.go
+++ b/structs.go
@@ -16,6 +16,7 @@ type TLSDetails struct {
 	JA3Hash string `json:"ja3_hash"`
 
 	JA4 string `json:"ja4"`
+	JA4_r string `json:"ja4_r"`
 
 	PeetPrint     string `json:"peetprint"`
 	PeetPrintHash string `json:"peetprint_hash"`
@@ -60,6 +61,7 @@ type SmallResponse struct {
 	JA3           string `json:"ja3"`
 	JA3Hash       string `json:"ja3_hash"`
 	JA4           string `json:"ja4"`
+	JA4_r           string `json:"ja4_r"`
 	Akamai        string `json:"akamai"`
 	AkamaiHash    string `json:"akamai_hash"`
 	PeetPrint     string `json:"peetprint"`


### PR DESCRIPTION
As you can see below, Wireshark supports `JA4_r`, which displays the value of the ja4 before its parts are hashed.
<img width="659" alt="Capture d’écran 2025-01-07 à 11 27 05" src="https://github.com/user-attachments/assets/73e9cedb-da93-4837-9b53-9993845edef9" />
It's pretty useful to see where an impersonation is wrong on the ja4, so I implemented it here. Here is the result of a test:
![IMG_0024](https://github.com/user-attachments/assets/bf431c38-fc46-49d5-9370-2a2494b49a27)
