### PR TITLE
Update the Dockerfile to align with go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine3.16
+FROM golang:1.23-alpine
 
 RUN apk add build-base
 RUN apk add libpcap-dev


### PR DESCRIPTION
In the current state, the Dockerfile can't be used