### PR TITLE
Add user_agent key while http1 parsing

### DIFF
--- a/connection_handler.go
+++ b/connection_handler.go
@@ -25,9 +25,13 @@ func parseHTTP1(request []byte) Response {
 
 	// Split the headers into an array
 	var headers []string
+    var userAgent string
 	for _, line := range lines {
 		if strings.Contains(line, ":") {
 			headers = append(headers, line)
+            if strings.HasPrefix(strings.ToLower(line), "user-agent") {
+                userAgent = strings.TrimSpace(strings.Split(line, ": ")[1])
+            }
 		}
 	}
 
@@ -42,6 +46,7 @@ func parseHTTP1(request []byte) Response {
 		HTTPVersion: firstLine[2],
 		path:        firstLine[1],
 		Method:      firstLine[0],
+        UserAgent:   userAgent,
 		Http1: &Http1Details{
 			Headers: headers,
 		},

--- a/connection_handler.go
+++ b/connection_handler.go
@@ -25,13 +25,13 @@ func parseHTTP1(request []byte) Response {
 
 	// Split the headers into an array
 	var headers []string
-    var userAgent string
+	var userAgent string
 	for _, line := range lines {
 		if strings.Contains(line, ":") {
 			headers = append(headers, line)
-            if strings.HasPrefix(strings.ToLower(line), "user-agent") {
-                userAgent = strings.TrimSpace(strings.Split(line, ": ")[1])
-            }
+			if strings.HasPrefix(strings.ToLower(line), "user-agent") {
+				userAgent = strings.TrimSpace(strings.Split(line, ": ")[1])
+			}
 		}
 	}
 
@@ -46,7 +46,7 @@ func parseHTTP1(request []byte) Response {
 		HTTPVersion: firstLine[2],
 		path:        firstLine[1],
 		Method:      firstLine[0],
-        UserAgent:   userAgent,
+		UserAgent:   userAgent,
 		Http1: &Http1Details{
 			Headers: headers,
 		},


### PR DESCRIPTION
Right now, we're not setting the User-Agent field when parsing HTTP/1.1 requests, but it would be a good idea to start doing that.